### PR TITLE
change how default MAX_DOC_TOKENS value is fetched

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -517,6 +517,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We are experiementing with other use cases like:
 Almost any RAG-based solution can be quickly implmented in fack.
 
 ## Why is it Called Fack?
-The term FAQ, or Frequently Asked Questions, is often pronounced [fack](https://english.stackexchange.com/questions/4165/what-is-the-commonly-accepted-pronunciation-of-faq).
+The term FAQ, or Frequently Asked Questions, is often pronounced [fack](https://english.stackexchange.com/questions/4165/what-is-the-commonly-accepted-pronunciation-of-faq). 
 
 ## Inspiration
 Fack is built on the principles outlined by OpenAI for question/answer applications in documents like:

--- a/app/jobs/generate_message_response_job.rb
+++ b/app/jobs/generate_message_response_job.rb
@@ -170,7 +170,7 @@ class GenerateMessageResponseJob < ApplicationJob
       prompt += "\n\n<DOCUMENTS>\n\n"
       if related_docs.each_with_index do |doc, index|
         # Make sure we don't exceed the max document tokens limit
-        max_doc_tokens = ENV['MAX_PROMPT_DOC_TOKENS'].to_i || 10_000
+        max_doc_tokens = ENV.fetch('MAX_DOC_TOKENS', '10_000').to_i
         next unless (token_count + doc.token_count.to_i) < max_doc_tokens
         next unless index < max_docs
 


### PR DESCRIPTION
`max_doc_tokens` is fetched through environment variables `ENV`, when such variable does not exist
`ENV['MAX_PROMPT_DOC_TOKENS'].to_i ` gets evaluated to 0 and `0 || 10000` becomes 0.

The result is that no actual docs can be included since the token size limit of the doc is 0. 
Based on the documentation, the expected behavior is that if this env variable is not included, it should be 10000 as default. 