### PR TITLE
fix the typo of MAX_DOC_TOKENS

### DIFF
--- a/app/jobs/generate_answer_job.rb
+++ b/app/jobs/generate_answer_job.rb
@@ -88,7 +88,7 @@ Rules:
     prompt += '<CONTEXT>'
     if related_docs.each_with_index do |doc, index|
       # Make sure we don't exceed the max document tokens limit
-      max_doc_tokens = ENV['MAX_PROMPT_DOC_TOKENS'].to_i || 10_000
+      max_doc_tokens = ENV.fetch('MAX_PROMPT_DOC_TOKENS', '10_000').to_i
       next unless (token_count + doc.token_count.to_i) < max_doc_tokens
       next unless index < max_docs
 

--- a/app/jobs/generate_message_response_job.rb
+++ b/app/jobs/generate_message_response_job.rb
@@ -170,7 +170,7 @@ class GenerateMessageResponseJob < ApplicationJob
       prompt += "\n\n<DOCUMENTS>\n\n"
       if related_docs.each_with_index do |doc, index|
         # Make sure we don't exceed the max document tokens limit
-        max_doc_tokens = ENV.fetch('MAX_DOC_TOKENS', '10_000').to_i
+        max_doc_tokens = ENV.fetch('MAX_PROMPT_DOC_TOKENS', '10_000').to_i
         next unless (token_count + doc.token_count.to_i) < max_doc_tokens
         next unless index < max_docs
 

--- a/spec/jobs/generate_answer_job_spec.rb
+++ b/spec/jobs/generate_answer_job_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe GenerateAnswerJob, type: :job do
     allow(ENV).to receive(:fetch).with('ROOT_URL', nil).and_return('http://example.com')
     allow(ENV).to receive(:[]).with('ALLOWED_ADDITIONAL_TOPICS').and_return('philosophy')
     allow(ENV).to receive(:[]).with('MAX_DOCS').and_return('7')
-    allow(ENV).to receive(:[]).with('MAX_PROMPT_DOC_TOKENS').and_return('1000')
+    allow(ENV).to receive(:fetch).with('MAX_PROMPT_DOC_TOKENS', '10_000').and_return('1000')
     allow(ENV).to receive(:[]).with('MT_DEBUG').and_return(nil)
     # Stub GptConcern methods
     allow_any_instance_of(GenerateAnswerJob).to receive(:get_embedding).and_return(Array.new(1536, 0.1))
@@ -46,7 +46,7 @@ RSpec.describe GenerateAnswerJob, type: :job do
 
       it 'limits documents to MAX_DOCS and MAX_PROMPT_DOC_TOKENS' do
         allow(ENV).to receive(:[]).with('MAX_DOCS').and_return('1')
-        allow(ENV).to receive(:[]).with('MAX_PROMPT_DOC_TOKENS').and_return('20')
+        allow(ENV).to receive(:fetch).with('MAX_PROMPT_DOC_TOKENS', '10_000').and_return('20')
 
         perform_enqueued_jobs { GenerateAnswerJob.perform_later(question.id) }
 


### PR DESCRIPTION
Fix a typo in [PR-159 ](https://github.com/salesforce/fack/pull/159) where `MAX_DOC_TOKENS` was used, which doesn't exist in documentation