### PR TITLE
add credential flow grant type

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ EGPT_GEN_MODEL=
 
 ## Disable Password Login if you have SSO enabled.  (OPTIONAL)
 DISABLE_PASSWORD_LOGIN=<true/false>
+
+## Whether to use credential flow grant type to get einstein tokens. If not set, it uses password grant type.(OPTIONAL)
+USE_CREDENTIAL_FLOW_AUTHENTICATION=true
 ```
 
 5. Open a new terminal and start the Background job for AI Calls

--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ EGPT_GEN_MODEL=
 ## Disable Password Login if you have SSO enabled.  (OPTIONAL)
 DISABLE_PASSWORD_LOGIN=<true/false>
 
-## Whether to use credential flow grant type to get einstein tokens. If not set, it uses password grant type.(OPTIONAL)
-USE_CREDENTIAL_FLOW_AUTHENTICATION=true
 ```
 
 5. Open a new terminal and start the Background job for AI Calls

--- a/app/controllers/concerns/gpt_concern.rb
+++ b/app/controllers/concerns/gpt_concern.rb
@@ -159,13 +159,23 @@ module GptConcern
     encoded_username = ENV.fetch('SALESFORCE_CONNECT_USERNAME', nil)
     encoded_password = ENV.fetch('SALESFORCE_CONNECT_PASSWORD', nil)
 
-    token_request_data = {
-      grant_type: 'password',
-      client_id: encoded_client_id,
-      client_secret: encoded_client_secret,
-      username: encoded_username,
-      password: encoded_password
-    }
+    use_credential_flow = ENV.fetch('USE_CREDENTIAL_FLOW_AUTHENTICATION', '').downcase == 'true'
+    token_request_data =
+      if use_credential_flow
+        {
+          grant_type: 'client_credentials',
+          client_id: encoded_client_id,
+          client_secret: encoded_client_secret
+        }
+     else
+        {
+          grant_type: 'password',
+          client_id: encoded_client_id,
+          client_secret: encoded_client_secret,
+          username: encoded_username,
+          password: encoded_password
+        }
+      end
 
     URI.encode_www_form(token_request_data)
     oauth_url = "#{ENV.fetch('SALESFORCE_CONNECT_ORG_URL', nil)}/services/oauth2/token"


### PR DESCRIPTION
Addresses: https://github.com/salesforce/fack/issues/176
where the `grant_type` can be either `client_credentials` or `password` 