### PR TITLE
Update Gemfile and Gemfile.lock to ensure compatibility with Rails 7.…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'jbuilder'
 
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.0'
+# Keep compatible with Rails 7.2 Redis cache store initialization
+gem 'connection_pool', '< 3.0'
 
 # Enable CORS for Chrome extension support
 gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       xpath (~> 3.2)
     cgi (0.5.1)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crass (1.0.6)
     csv (3.3.5)
     daemons (1.4.1)
@@ -555,6 +555,7 @@ DEPENDENCIES
   brakeman
   bundle-audit
   capybara
+  connection_pool (< 3.0)
   daemons
   debug
   delayed_job_active_record


### PR DESCRIPTION
…2 Redis cache store initialization by specifying connection_pool version constraint. Downgraded connection_pool to version 2.5.5 in Gemfile.lock.