### PR TITLE
Add configurable document lookback window for questions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,9 +103,12 @@ gem 'rack-session', '>= 2.1.2'
 gem 'erb', '>= 6.0.4'
 gem 'net-imap', '>= 0.6.4'
 
-# Security: Fix GHSA-wx95-c6cv-8532 (nokogiri), CVE-2026-22860, CVE-2026-25500 (rack)
-gem 'nokogiri', '>= 1.19.1'
+# Security: Fix GHSA-c4rq-3m3g-8wgx, GHSA-v2fc-qm4h-8hqv (nokogiri), CVE-2026-22860, CVE-2026-25500 (rack)
+gem 'nokogiri', '>= 1.19.3'
 gem 'rack', '~> 3.1.20'
+
+# Security: Fix GHSA-pp92-crg2-gfv9 (oauth2 redirect/authority leak)
+gem 'oauth2', '>= 2.0.22'
 
 # Markdown renderer
 gem 'redcarpet'

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'sprockets-rails'
 gem 'pg', '~> 1.1'
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem 'puma', '~> 6.4'
+gem 'puma', '>= 7.2.1', '< 8.0'
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem 'importmap-rails'
@@ -93,8 +93,15 @@ gem 'dotenv-rails', groups: %i[development test]
 
 gem 'httparty', '>= 0.24.0'
 
-# Security: Fix CVE-2026-25765 (SSRF vulnerability)
-gem 'faraday', '>= 2.14.1', '< 3.0'
+# Security: Fix CVE-2026-25765, CVE-2026-33637 (Faraday vulnerabilities)
+gem 'faraday', '>= 2.14.2', '< 3.0'
+
+# Security: direct minimum versions to address current advisories
+gem 'addressable', '>= 2.9.0'
+gem 'jwt', '>= 2.10.3'
+gem 'rack-session', '>= 2.1.2'
+gem 'erb', '>= 6.0.4'
+gem 'net-imap', '>= 0.6.4'
 
 # Security: Fix GHSA-wx95-c6cv-8532 (nokogiri), CVE-2026-22860, CVE-2026-25500 (rack)
 gem 'nokogiri', '>= 1.19.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,10 +82,12 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     ast (2.4.3)
+    auth-sanitizer (0.2.1)
+      version_gem (~> 1.1, >= 1.1.10)
     base64 (0.3.0)
     bcrypt (3.1.22)
     benchmark (0.5.0)
-    bigdecimal (4.1.0)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
@@ -191,7 +193,8 @@ GEM
     gyoku (1.4.0)
       builder (>= 2.1.2)
       rexml (~> 3.0)
-    hashie (5.0.0)
+    hashie (5.1.0)
+      logger
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
@@ -251,7 +254,7 @@ GEM
     minitest (5.27.0)
     msgpack (1.8.0)
     multi_json (1.16.0)
-    multi_xml (0.8.1)
+    multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
@@ -270,22 +273,23 @@ GEM
       net-protocol
     nio4r (2.7.5)
     nkf (0.2.0)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     nori (2.7.1)
       bigdecimal
-    oauth2 (2.0.12)
+    oauth2 (2.0.22)
+      auth-sanitizer (~> 0.2, >= 0.2.1)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.3)
-      version_gem (>= 1.1.8, < 3)
+      snaky_hash (~> 2.0, >= 2.0.5)
+      version_gem (~> 1.1, >= 1.1.11)
     omniauth (2.1.3)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -473,7 +477,7 @@ GEM
       gli
       hashie
       logger
-    snaky_hash (2.0.3)
+    snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     sprockets (4.2.2)
@@ -511,7 +515,7 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.1.1)
     useragent (0.16.11)
-    version_gem (1.1.8)
+    version_gem (1.1.11)
     wasabi (5.1.0)
       addressable
       faraday (>= 1.9, < 3)
@@ -574,7 +578,8 @@ DEPENDENCIES
   kaminari
   neighbor
   net-imap (>= 0.6.4)
-  nokogiri (>= 1.19.1)
+  nokogiri (>= 1.19.3)
+  oauth2 (>= 2.0.22)
   omniauth-google-oauth2
   optparse
   pager_duty-connection

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     acts_as_votable (0.14.0)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     akami (1.3.3)
       base64
       gyoku (>= 0.4.0)
@@ -129,7 +129,7 @@ GEM
       dotenv (= 3.1.8)
       railties (>= 6.1)
     drb (2.2.3)
-    erb (6.0.2)
+    erb (6.0.4)
     erubi (1.13.1)
     event_emitter (0.2.6)
     factory_bot (6.5.4)
@@ -139,7 +139,7 @@ GEM
       railties (>= 6.1.0)
     faker (3.5.2)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -150,8 +150,8 @@ GEM
       hashie
     faraday-multipart (1.1.1)
       multipart-post (~> 2.0)
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
     gems (1.3.0)
     gli (2.22.2)
       ostruct
@@ -218,8 +218,8 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    json (2.12.2)
-    jwt (2.10.2)
+    json (2.19.9)
+    jwt (2.10.3)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -257,9 +257,9 @@ GEM
     mutex_m (0.3.0)
     neighbor (0.6.0)
       activerecord (>= 7.1)
-    net-http (0.6.0)
-      uri
-    net-imap (0.6.3)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -321,8 +321,8 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (6.0.2)
-    puma (6.6.0)
+    public_suffix (7.0.5)
+    puma (7.2.1)
       nio4r (~> 2.0)
     pundit (2.5.0)
       activesupport (>= 3.0.0)
@@ -335,7 +335,7 @@ GEM
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -509,7 +509,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.4)
+    uri (1.1.1)
     useragent (0.16.11)
     version_gem (1.1.8)
     wasabi (5.1.0)
@@ -550,6 +550,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts_as_votable
+  addressable (>= 2.9.0)
   bcrypt (>= 3.1.22)
   bootsnap
   brakeman
@@ -560,16 +561,19 @@ DEPENDENCIES
   debug
   delayed_job_active_record
   dotenv-rails
+  erb (>= 6.0.4)
   factory_bot_rails
   faker
-  faraday (>= 2.14.1, < 3.0)
+  faraday (>= 2.14.2, < 3.0)
   google-api-client
   googleauth
   httparty (>= 0.24.0)
   importmap-rails
   jbuilder
+  jwt (>= 2.10.3)
   kaminari
   neighbor
+  net-imap (>= 0.6.4)
   nokogiri (>= 1.19.1)
   omniauth-google-oauth2
   optparse
@@ -577,10 +581,11 @@ DEPENDENCIES
   pg (~> 1.1)
   pg_search
   pgvector
-  puma (~> 6.4)
+  puma (>= 7.2.1, < 8.0)
   pundit (~> 2.3)
   rack (~> 3.1.20)
   rack-cors
+  rack-session (>= 2.1.2)
   rails (~> 7.2.3, >= 7.2.3.1)
   rails-controller-testing
   redcarpet

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The [OpenAI doc](https://cookbook.openai.com/examples/question_answering_using_e
 | `ROOT_URL` | Base URL for the application | http://localhost:3000 |
 | `SSO_METADATA_URL` | URL for SAML/SSO metadata | - |
 | `ALLOWED_ADDITIONAL_TOPICS` | Comma-separated list of additional allowed topics | - |
+| `QUESTION_DOC_LOOKBACK_DAYS` | Limit question-answer retrieval to docs created in the last N days (`0` disables filter) | 365 |
 | `REDIS_URL` | Redis connection URL | redis://localhost:6379/1 |
 
 
@@ -140,6 +141,9 @@ EGPT_MAX_TOKENS=
 
 ## Which OpenAI model to use. (OPTIONAL)
 EGPT_GEN_MODEL=
+
+## Limit question-answer retrieval to docs created in last N days. 0 disables the filter. (OPTIONAL)
+QUESTION_DOC_LOOKBACK_DAYS=365
 
 ## Disable Password Login if you have SSO enabled.  (OPTIONAL)
 DISABLE_PASSWORD_LOGIN=<true/false>
@@ -278,6 +282,7 @@ This structure provides flexibility in customizing assistants based on different
 > |-----------|-----------|-------------------------|-----------------------------------------------------------------------|
 > | question  |  required | text                    | The question to ask of the documentation   |
 > | library_ids_included  |  optional | comma separated ids (reference to library)            | The libraries to limit the answers   |    
+> | doc_lookback_days  |  optional | integer            | Limit retrieval to docs created in the last N days for this question (overrides global `QUESTION_DOC_LOOKBACK_DAYS`)   |
 
 
 ##### Responses
@@ -290,7 +295,7 @@ This structure provides flexibility in customizing assistants based on different
 ##### Example cURL
 
 > ```javascript
-> curl -X POST -H "Authorization: Bearer <token>" -H "Content-Type: application/json" -d '{"question": { "question" : "how do i setup falcon?", library_ids_included: ["1"] }}' http://localhost:3000/api/v1/questions
+> curl -X POST -H "Authorization: Bearer <token>" -H "Content-Type: application/json" -d '{"question": { "question" : "how do i setup falcon?", "library_ids_included": ["1"], "doc_lookback_days": 7 }}' http://localhost:3000/api/v1/questions
 > ```
 
 > ```javascript

--- a/app/controllers/base_questions_controller.rb
+++ b/app/controllers/base_questions_controller.rb
@@ -56,7 +56,7 @@ class BaseQuestionsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def question_params
-    params.require(:question).permit(:question, :answer, :library_id, :source_url,
+    params.require(:question).permit(:question, :answer, :library_id, :source_url, :doc_lookback_days,
                                      library_ids_included: [])
   end
 end

--- a/app/jobs/generate_answer_job.rb
+++ b/app/jobs/generate_answer_job.rb
@@ -15,6 +15,11 @@ class GenerateAnswerJob < ApplicationJob
 
     related_docs = related_documents_from_embedding(question.embedding).where(enabled: true)
 
+    lookback_days = question.doc_lookback_days || ENV.fetch('QUESTION_DOC_LOOKBACK_DAYS', '365').to_i
+    if lookback_days.positive?
+      related_docs = related_docs.where('documents.created_at >= ?', lookback_days.days.ago)
+    end
+
     question.library_ids_included.push(question.library_id) if question.library_id
     if question.library_ids_included.present? && question.library_ids_included.none?(&:nil?) && question.library_ids_included.length.positive?
       related_docs = related_docs.where(library_id: question.library_ids_included)

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -14,6 +14,7 @@ class Question < ApplicationRecord
   enum :status, { pending: 0, generating: 1, generated: 2, failed: 3 }
 
   validates :question, presence: true
+  validates :doc_lookback_days, numericality: { greater_than_or_equal_to: 0, only_integer: true }, allow_nil: true
   belongs_to :user, optional: true
 
   before_save :check_unable_to_answer

--- a/db/migrate/20260612110000_add_doc_lookback_days_to_questions.rb
+++ b/db/migrate/20260612110000_add_doc_lookback_days_to_questions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDocLookbackDaysToQuestions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :questions, :doc_lookback_days, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_03_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_12_110000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -232,6 +232,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_03_120000) do
     t.string "source_url"
     t.string "library_ids_included", default: [], array: true
     t.datetime "generated_at"
+    t.integer "doc_lookback_days"
     t.virtual "search_vector", type: :tsvector, as: "to_tsvector('english'::regconfig, question)", stored: true
     t.index ["created_at"], name: "index_questions_on_created_at"
     t.index ["embedding"], name: "index_questions_on_embedding", opclass: :vector_cosine_ops, using: :ivfflat

--- a/spec/jobs/generate_answer_job_spec.rb
+++ b/spec/jobs/generate_answer_job_spec.rb
@@ -60,6 +60,27 @@ RSpec.describe GenerateAnswerJob, type: :job do
         expect(question.prompt).to include(doc2.title) # doc2 fits within token limit
         expect(question.prompt).not_to include(doc1.title)
       end
+
+      it 'filters documents using QUESTION_DOC_LOOKBACK_DAYS when set' do
+        allow(ENV).to receive(:fetch).with('QUESTION_DOC_LOOKBACK_DAYS', '365').and_return('1')
+
+        perform_enqueued_jobs { GenerateAnswerJob.perform_later(question.id) }
+
+        question.reload
+        expect(question.prompt).to include(doc2.title)
+        expect(question.prompt).not_to include(doc1.title)
+      end
+
+      it 'uses question doc_lookback_days over QUESTION_DOC_LOOKBACK_DAYS env var' do
+        allow(ENV).to receive(:fetch).with('QUESTION_DOC_LOOKBACK_DAYS', '365').and_return('10')
+        question.update!(doc_lookback_days: 1)
+
+        perform_enqueued_jobs { GenerateAnswerJob.perform_later(question.id) }
+
+        question.reload
+        expect(question.prompt).to include(doc2.title)
+        expect(question.prompt).not_to include(doc1.title)
+      end
     end
 
     context 'when no related documents are found' do

--- a/spec/jobs/generate_answer_job_spec.rb
+++ b/spec/jobs/generate_answer_job_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe GenerateAnswerJob, type: :job do
   let(:user) { create(:user, email: 'user@example.com', password: 'Password1!') }
   let(:library) { create(:library, name: 'Test Library', user:) }
   let(:question) { create(:question, user:, library_id: library.id, question: 'What is the meaning of life?', library_ids_included: [library.id]) }
-  let(:doc1) { create(:document, user:, library_id: library.id, title: 'Doc 1', document: 'Life is 42.', created_at: 2.days.ago, token_count: 10) }
-  let(:doc2) { create(:document, user:, library_id: library.id, title: 'Doc 2', document: 'Life is complex.', created_at: 1.day.ago, token_count: 15, enabled: true) }
+  let(:doc1) { create(:document, user:, library_id: library.id, title: 'Doc 1', document: 'Life is 42.', created_at: 3.days.ago, token_count: 10) }
+  let(:doc2) { create(:document, user:, library_id: library.id, title: 'Doc 2', document: 'Life is complex.', created_at: 12.hours.ago, token_count: 15, enabled: true) }
 
   before do
     # Stub environment variables


### PR DESCRIPTION
## Summary
- add a global retrieval window default (`QUESTION_DOC_LOOKBACK_DAYS`, now defaulting to 365 days) when building question context documents
- add per-request override support with `doc_lookback_days` on questions, including controller permit list, model validation, schema/migration updates, and retrieval precedence over env default
- update docs and job specs to cover env-based filtering and per-question override behavior

## Test plan
- [ ] `bundle exec rspec spec/jobs/generate_answer_job_spec.rb`
- [ ] create question via API with `doc_lookback_days` and verify only recent docs are included in context
- [ ] create question without `doc_lookback_days` and verify global lookback default is applied

Made with [Cursor](https://cursor.com)