### PR TITLE
Fix similar_to vector query ordering for large libraries

### DIFF
--- a/app/controllers/base_documents_controller.rb
+++ b/app/controllers/base_documents_controller.rb
@@ -61,8 +61,8 @@ class BaseDocumentsController < ApplicationController
       # Get similar documents but preserve existing filters
       @documents = @documents.related_by_embedding(embedding)
 
-      # Sort by neighbor_distance using SQL to maintain ActiveRecord relation
-      @documents = @documents.order('neighbor_distance ASC')
+      # Force pure distance ordering to keep nearest-neighbor queries index-friendly.
+      @documents = @documents.reorder('neighbor_distance ASC')
     else
       # Only apply default sorting if not doing similarity search
       @documents = if params[:sort] == 'questions'

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -82,8 +82,7 @@ class Document < ApplicationRecord
   # Because of the ordering, having too many documents may cause the most relevant documents to be lost.
   scope :related_by_embedding, lambda { |embedding, limit = nil|
     limit ||= ENV.fetch('RELATED_DOCUMENTS_LIMIT', 25).to_i
-    scope = nearest_neighbors(:embedding, embedding, distance: 'euclidean')
-    scope.order(updated_at: :desc).limit(limit)
+    nearest_neighbors(:embedding, embedding, distance: 'euclidean').limit(limit)
   }
 
   # Default scope to only show non-deleted documents


### PR DESCRIPTION
## Summary
- remove `updated_at` ordering from `Document.related_by_embedding` so nearest-neighbor distance ordering remains index-friendly
- use `reorder('neighbor_distance ASC')` in the `similar_to` path so prior scope ordering cannot force expensive re-sorting
- keep semantic ranking distance-first for large library queries

## Test plan
- [x] Manual rails console validation for `library_id=327` showed near-instant response with distance-only query shape
- [x] Verified changed files are lint-clean

Made with [Cursor](https://cursor.com)