### PR TITLE
Fix similar_to vector query performance on large libraries

### DIFF
--- a/app/controllers/base_documents_controller.rb
+++ b/app/controllers/base_documents_controller.rb
@@ -60,9 +60,6 @@ class BaseDocumentsController < ApplicationController
       embedding = get_embedding(params[:similar_to])
       # Get similar documents but preserve existing filters
       @documents = @documents.related_by_embedding(embedding)
-
-      # Force pure distance ordering to keep nearest-neighbor queries index-friendly.
-      @documents = @documents.reorder('neighbor_distance ASC')
     else
       # Only apply default sorting if not doing similarity search
       @documents = if params[:sort] == 'questions'

--- a/app/controllers/base_documents_controller.rb
+++ b/app/controllers/base_documents_controller.rb
@@ -61,8 +61,8 @@ class BaseDocumentsController < ApplicationController
       # Get similar documents but preserve existing filters
       @documents = @documents.related_by_embedding(embedding)
 
-      # Sort by neighbor_distance using SQL to maintain ActiveRecord relation
-      @documents = @documents.order('neighbor_distance ASC')
+      # Force pure distance ordering to keep nearest-neighbor queries index-friendly.
+      @documents = @documents.reorder('neighbor_distance ASC')
     else
       # Only apply default sorting if not doing similarity search
       @documents = if params[:sort] == 'questions'

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -82,8 +82,7 @@ class Document < ApplicationRecord
   # Because of the ordering, having too many documents may cause the most relevant documents to be lost.
   scope :related_by_embedding, lambda { |embedding, limit = nil|
     limit ||= ENV.fetch('RELATED_DOCUMENTS_LIMIT', 25).to_i
-    scope = nearest_neighbors(:embedding, embedding, distance: 'euclidean')
-    scope.order(updated_at: :desc).limit(limit)
+    nearest_neighbors(:embedding, embedding, distance: 'euclidean').limit(limit)
   }
 
   # Default scope to only show non-deleted documents


### PR DESCRIPTION
## Summary
- remove `updated_at` ordering from `Document.related_by_embedding` so nearest-neighbor retrieval stays index-friendly on large libraries
- keep `similar_to` controller path simple by relying on `related_by_embedding` / `nearest_neighbors` ordering (no alias-based reordering)
- preserve result behavior while avoiding the timeout-prone query shape on large libraries like `327`

## Test plan
- [x] Rails console: `nearest_neighbors(...).limit(10)` returns rows for library `327`
- [x] Rails console: `related_by_embedding(...).limit(10)` returns rows for library `327`
- [x] Rails console sanity check returns rows for smaller library (`129`)

Made with [Cursor](https://cursor.com)