### PR TITLE
Ensure similar_to ef_search setting applies to executed query

### DIFF
--- a/app/controllers/base_documents_controller.rb
+++ b/app/controllers/base_documents_controller.rb
@@ -67,8 +67,8 @@ class BaseDocumentsController < ApplicationController
       end
 
       if similar_document_ids.present?
-        order_sql = similar_document_ids.each_with_index.map { |id, index| "WHEN #{id} THEN #{index}" }.join(' ')
-        @documents = @documents.where(id: similar_document_ids).order(Arel.sql("CASE documents.id #{order_sql} END"))
+        # Preserve nearest-neighbor relevance order without interpolating SQL.
+        @documents = @documents.where(id: similar_document_ids).in_order_of(:id, similar_document_ids)
       else
         @documents = @documents.none
       end

--- a/app/controllers/base_documents_controller.rb
+++ b/app/controllers/base_documents_controller.rb
@@ -60,9 +60,17 @@ class BaseDocumentsController < ApplicationController
       embedding = get_embedding(params[:similar_to])
       # Use a higher HNSW search breadth for filtered similarity queries.
       # This improves recall on large libraries with additional date/library filters.
+      similar_document_ids = []
       Document.transaction do
         ActiveRecord::Base.connection.execute('SET LOCAL hnsw.ef_search = 1000')
-        @documents = @documents.related_by_embedding(embedding)
+        similar_document_ids = @documents.related_by_embedding(embedding).pluck(:id)
+      end
+
+      if similar_document_ids.present?
+        order_sql = similar_document_ids.each_with_index.map { |id, index| "WHEN #{id} THEN #{index}" }.join(' ')
+        @documents = @documents.where(id: similar_document_ids).order(Arel.sql("CASE documents.id #{order_sql} END"))
+      else
+        @documents = @documents.none
       end
     else
       # Only apply default sorting if not doing similarity search


### PR DESCRIPTION
## Summary
- keep `SET LOCAL hnsw.ef_search = 1000` for `similar_to` retrieval
- execute the nearest-neighbor SQL inside that transaction by materializing `pluck(:id)` in the block
- rebuild the final relation from those ids in preserved relevance order so pagination/rendering does not re-run ANN outside the transaction

## Test plan
- [x] Lints pass for modified controller file
- [x] SQL flow review confirms ANN query now executes inside transaction scope where `SET LOCAL` is active
- [x] No changes outside `app/controllers/base_documents_controller.rb`

 Why this fixes the ef_search issue

  The original bug: related_by_embedding returns a lazy ActiveRecord::Relation — assigning it runs no SQL. Since SET LOCAL hnsw.ef_search = 1000 is scoped to its transaction, by
  the time the ANN query actually executed (later, during pagination/rendering) the transaction was already closed and ef_search had reverted to its default. The tuning never
  reached the query.

  Document.transaction do
    ActiveRecord::Base.connection.execute('SET LOCAL hnsw.ef_search = 1000')
    @documents = @documents.related_by_embedding(embedding)   # lazy — runs NO SQL
  end
  # transaction ends → SET LOCAL discarded → query runs later with default ef_search

  The fix: .pluck(:id) forces the ANN query to execute immediately, inside the transaction, on the same connection where SET LOCAL is active — so the tuned recall setting genuinely
  applies.

  Document.transaction do
    ActiveRecord::Base.connection.execute('SET LOCAL hnsw.ef_search = 1000')
    similar_document_ids = @documents.related_by_embedding(embedding).pluck(:id)   # forces SQL NOW
  end

  The in_order_of step afterward just re-fetches those ids in relevance order for pagination/display, without re-running ANN (so no ef_search needed there). It also replaces the
  earlier interpolated Arel.sql CASE, clearing the Brakeman SQL injection warning.



Made with [Cursor](https://cursor.com)