### PR TITLE
Add keyword/semantic search mode toggle on documents page

### DIFF
--- a/app/controllers/base_documents_controller.rb
+++ b/app/controllers/base_documents_controller.rb
@@ -53,21 +53,17 @@ class BaseDocumentsController < ApplicationController
       end
     end
 
-    search_mode = params[:search_mode].presence
-    search_query = params[:query].presence
-    contains_query = params[:contains].presence
-    similar_to_query = params[:similar_to].presence
-
-    # Search mode from UI uses a single query parameter.
-    if search_query.present? && search_mode == 'keyword'
-      @documents = @documents.smart_search(search_query)
-    elsif search_query.present? && search_mode == 'semantic'
-      @documents = semantic_search_documents(@documents, search_query)
-    # Backward compatibility for existing API/query params.
-    elsif contains_query.present?
-      @documents = @documents.smart_search(contains_query)
-    elsif similar_to_query.present?
-      @documents = semantic_search_documents(@documents, similar_to_query)
+    # Contains should take priority and we shouldn't do similarity and contains
+    if params[:contains].present?
+      @documents = @documents.smart_search(params[:contains])
+    elsif params[:similar_to].present?
+      embedding = get_embedding(params[:similar_to])
+      # Use a higher HNSW search breadth for filtered similarity queries.
+      # This improves recall on large libraries with additional date/library filters.
+      Document.transaction do
+        ActiveRecord::Base.connection.execute('SET LOCAL hnsw.ef_search = 1000')
+        @documents = @documents.related_by_embedding(embedding)
+      end
     else
       # Only apply default sorting if not doing similarity search
       @documents = if params[:sort] == 'questions'
@@ -80,8 +76,7 @@ class BaseDocumentsController < ApplicationController
     end
 
     # Avoid loading heavy columns (document body, embedding vector, search_vector) for list
-    semantic_search_active = (search_query.present? && search_mode == 'semantic') || similar_to_query.present?
-    unless semantic_search_active
+    unless params[:similar_to].present?
       heavy = %w[embedding search_vector]
       list_columns = (Document.column_names - heavy).map { |c| "documents.#{c}" }
       @documents = @documents.select(list_columns.join(", "))
@@ -201,15 +196,6 @@ class BaseDocumentsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def document_params
     params.require(:document).permit(:document, :title, :enabled, :external_id, :url, :library_id, :source_url)
-  end
-
-  def semantic_search_documents(base_scope, query_text)
-    embedding = get_embedding(query_text)
-
-    Document.transaction do
-      ActiveRecord::Base.connection.execute('SET LOCAL hnsw.ef_search = 1000')
-      base_scope.related_by_embedding(embedding)
-    end
   end
 
   # Parse and validate the :since parameter

--- a/app/controllers/base_documents_controller.rb
+++ b/app/controllers/base_documents_controller.rb
@@ -53,17 +53,21 @@ class BaseDocumentsController < ApplicationController
       end
     end
 
-    # Contains should take priority and we shouldn't do similarity and contains
-    if params[:contains].present?
-      @documents = @documents.smart_search(params[:contains])
-    elsif params[:similar_to].present?
-      embedding = get_embedding(params[:similar_to])
-      # Use a higher HNSW search breadth for filtered similarity queries.
-      # This improves recall on large libraries with additional date/library filters.
-      Document.transaction do
-        ActiveRecord::Base.connection.execute('SET LOCAL hnsw.ef_search = 1000')
-        @documents = @documents.related_by_embedding(embedding)
-      end
+    search_mode = params[:search_mode].presence
+    search_query = params[:query].presence
+    contains_query = params[:contains].presence
+    similar_to_query = params[:similar_to].presence
+
+    # Search mode from UI uses a single query parameter.
+    if search_query.present? && search_mode == 'keyword'
+      @documents = @documents.smart_search(search_query)
+    elsif search_query.present? && search_mode == 'semantic'
+      @documents = semantic_search_documents(@documents, search_query)
+    # Backward compatibility for existing API/query params.
+    elsif contains_query.present?
+      @documents = @documents.smart_search(contains_query)
+    elsif similar_to_query.present?
+      @documents = semantic_search_documents(@documents, similar_to_query)
     else
       # Only apply default sorting if not doing similarity search
       @documents = if params[:sort] == 'questions'
@@ -76,7 +80,8 @@ class BaseDocumentsController < ApplicationController
     end
 
     # Avoid loading heavy columns (document body, embedding vector, search_vector) for list
-    unless params[:similar_to].present?
+    semantic_search_active = (search_query.present? && search_mode == 'semantic') || similar_to_query.present?
+    unless semantic_search_active
       heavy = %w[embedding search_vector]
       list_columns = (Document.column_names - heavy).map { |c| "documents.#{c}" }
       @documents = @documents.select(list_columns.join(", "))
@@ -196,6 +201,15 @@ class BaseDocumentsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def document_params
     params.require(:document).permit(:document, :title, :enabled, :external_id, :url, :library_id, :source_url)
+  end
+
+  def semantic_search_documents(base_scope, query_text)
+    embedding = get_embedding(query_text)
+
+    Document.transaction do
+      ActiveRecord::Base.connection.execute('SET LOCAL hnsw.ef_search = 1000')
+      base_scope.related_by_embedding(embedding)
+    end
   end
 
   # Parse and validate the :since parameter

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -14,9 +14,18 @@
     <% action_path = @library.present? ? library_documents_path(@library) : documents_path %>
     <%= form_with(url: action_path, method: :get, local: true, class: "w-full") do %>
       <div class="flex flex-col space-y-3">
-        <!-- Text Search -->
-        <div class="flex">
-          <input type="text" name="contains" id="contains" value="<%= params[:contains] %>" placeholder="Search documents..." class="flex-grow rounded-lg p-2 border border-stone-300">
+        <!-- Search Query + Mode -->
+        <div class="flex items-end space-x-2">
+          <div class="w-52">
+            <label for="search_mode" class="block text-sm font-medium text-stone-700 mb-1">Search Mode:</label>
+            <select name="search_mode" id="search_mode" class="w-full rounded-lg p-2 border border-stone-300 text-sm">
+              <% selected_mode = params[:search_mode].presence || (params[:similar_to].present? ? 'semantic' : 'keyword') %>
+              <option value="keyword" <%= 'selected' if selected_mode == 'keyword' %>>Keyword</option>
+              <option value="semantic" <%= 'selected' if selected_mode == 'semantic' %>>Semantic</option>
+            </select>
+          </div>
+          <% query_value = params[:query].presence || params[:contains].presence || params[:similar_to].presence %>
+          <input type="text" name="query" id="query" value="<%= query_value %>" placeholder="Search documents..." class="flex-grow rounded-lg p-2 border border-stone-300">
           <button type="submit" class="ml-2 rounded-lg p-2 bg-white text-sky-500 border-sky-500 border">Search</button>
         </div>
         <!-- Date Range Filters -->

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -12,7 +12,7 @@
   <!-- Search Form -->
   <div class="mt-3">
     <% action_path = @library.present? ? library_documents_path(@library) : documents_path %>
-    <%= form_with(url: action_path, method: :get, local: true, class: "w-full") do %>
+    <%= form_with(url: action_path, method: :get, local: true, class: "w-full", id: "documents-search-form") do %>
       <div class="flex flex-col space-y-3">
         <!-- Search Query + Mode -->
         <div class="flex items-end space-x-2">
@@ -26,6 +26,8 @@
           </div>
           <% query_value = params[:query].presence || params[:contains].presence || params[:similar_to].presence %>
           <input type="text" name="query" id="query" value="<%= query_value %>" placeholder="Search documents..." class="flex-grow rounded-lg p-2 border border-stone-300">
+          <input type="hidden" name="contains" id="contains_hidden" value="<%= params[:contains] %>">
+          <input type="hidden" name="similar_to" id="similar_to_hidden" value="<%= params[:similar_to] %>">
           <button type="submit" class="ml-2 rounded-lg p-2 bg-white text-sky-500 border-sky-500 border">Search</button>
         </div>
         <!-- Date Range Filters -->
@@ -44,6 +46,30 @@
       </div>
     <% end %>
   </div>
+  <script>
+    (function() {
+      var form = document.getElementById('documents-search-form');
+      if (!form) return;
+
+      form.addEventListener('submit', function() {
+        var mode = document.getElementById('search_mode');
+        var query = document.getElementById('query');
+        var containsHidden = document.getElementById('contains_hidden');
+        var similarToHidden = document.getElementById('similar_to_hidden');
+        var value = (query && query.value ? query.value.trim() : '');
+
+        if (!mode || !containsHidden || !similarToHidden) return;
+
+        if (mode.value === 'semantic') {
+          similarToHidden.value = value;
+          containsHidden.value = '';
+        } else {
+          containsHidden.value = value;
+          similarToHidden.value = '';
+        }
+      });
+    })();
+  </script>
   <div class="flex-grow flex items-center mt-3">
     <% if params[:sort].nil? %>
       <%= link_to 'Sort by Popularity', 


### PR DESCRIPTION
## Summary
- add a search mode selector to `/documents` so users can choose **Keyword** or **Semantic** search explicitly
- switch the documents index form to use a single `query` field, routed by `search_mode`
- keep backward compatibility for existing clients using `contains`/`similar_to` params

## Test plan
- [x] Verified lints on changed files
- [x] Confirmed controller routes `search_mode=keyword` to `smart_search`
- [x] Confirmed controller routes `search_mode=semantic` to vector search path with HNSW tuning

Made with [Cursor](https://cursor.com)