### PR TITLE
Qualify updated_at in document filters to avoid ambiguous column

### DIFF
--- a/app/controllers/base_documents_controller.rb
+++ b/app/controllers/base_documents_controller.rb
@@ -29,7 +29,7 @@ class BaseDocumentsController < ApplicationController
     if params[:since].present?
       begin
         since_date = parse_since_parameter(params[:since])
-        @documents = @documents.where('updated_at > ?', since_date)
+        @documents = @documents.where('documents.updated_at > ?', since_date)
       rescue ArgumentError => e
         respond_to do |format|
           format.html { redirect_to documents_path, alert: "Invalid date format for 'since' parameter: #{e.message}" }
@@ -43,7 +43,7 @@ class BaseDocumentsController < ApplicationController
     if params[:until].present?
       begin
         until_date = parse_since_parameter(params[:until])
-        @documents = @documents.where('updated_at < ?', until_date)
+        @documents = @documents.where('documents.updated_at < ?', until_date)
       rescue ArgumentError => e
         respond_to do |format|
           format.html { redirect_to documents_path, alert: "Invalid date format for 'until' parameter: #{e.message}" }

--- a/test/fixtures/api_tokens.yml
+++ b/test/fixtures/api_tokens.yml
@@ -4,8 +4,16 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-# column: value
+one:
+  active: true
+  token: token_one
+  name: Token One
+  user: one
+  source: web
+
+two:
+  active: true
+  token: token_two
+  name: Token Two
+  user: two
+  source: web

--- a/test/models/document_similarity_filter_test.rb
+++ b/test/models/document_similarity_filter_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Regression coverage for PG::AmbiguousColumn on the documents index.
+#
+# The index eager-loads :library and :user. When those associations are
+# forced into the query as JOINs (e.g. by materializing similarity results
+# with pluck) *and* a date filter references `updated_at`, an unqualified
+# `updated_at` is ambiguous because documents, libraries, and users all have
+# that column. The filter must qualify the column as `documents.updated_at`.
+class DocumentSimilarityFilterTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @library = libraries(:one)
+    Document.create!(
+      title: 'Similarity Doc',
+      document: 'similarity content',
+      library: @library,
+      user: @user,
+      embedding: Array.new(1536, 0.1)
+    )
+  end
+
+  # Mirrors the controller's similar_to path: eager-loaded associations, a
+  # `since` date filter, nearest-neighbor ordering, then materialization.
+  # `eager_load` forces the LEFT OUTER JOINs that make a bare `updated_at`
+  # ambiguous.
+  def materialized_ids_with(updated_at_predicate)
+    Document
+      .eager_load(:library, :user)
+      .where(library_id: @library.id)
+      .where(updated_at_predicate, '2000-01-01')
+      .related_by_embedding(Array.new(1536, 0.1))
+      .pluck(:id)
+  end
+
+  test 'qualified documents.updated_at filter does not raise ambiguous column' do
+    assert_nothing_raised do
+      materialized_ids_with('documents.updated_at > ?')
+    end
+  end
+
+  test 'unqualified updated_at filter is ambiguous when associations are joined' do
+    # Guards that the scenario is real: without qualification Postgres raises.
+    error = assert_raises(ActiveRecord::StatementInvalid) do
+      materialized_ids_with('updated_at > ?')
+    end
+    assert_match(/ambiguous/i, error.message)
+  end
+end


### PR DESCRIPTION
## Problem

The documents index (`BaseDocumentsController#index`) 500s with `PG::AmbiguousColumn: column reference "updated_at" is ambiguous` when a `since`/`until` date filter is combined with a similarity search whose results are materialized.

The index eager-loads `:library` and `:user`. When those associations get forced into the query as `LEFT OUTER JOIN`s (e.g. when similarity results are materialized via `pluck`), the bare `where('updated_at > ?')` filter becomes ambiguous — `documents`, `libraries`, and `users` all have an `updated_at` column.

## Fix

Qualify the column as `documents.updated_at` in both the `since` and `until` branches.

## Tests

Added `test/models/document_similarity_filter_test.rb`, which reproduces the exact failing query shape (eager-loaded associations + `updated_at` filter + materialization):
- Confirms the qualified filter runs cleanly.
- Confirms the *unqualified* filter raises `PG::AmbiguousColumn` — so this is a real regression guard, not a no-op.

## Incidental

The `api_tokens` fixture was empty (`{}`) while the schema requires a non-null `user_id`, which caused `fixtures :all` to fail and blocked the entire test suite from loading. Populated it minimally so tests can run.

## Note

On `main` today this bug is latent: the controller's `similar_to` path is lazy, so `includes` runs as separate preload queries with no JOIN, and the ambiguity isn't reachable through a normal request. The JOIN (and the crash) appears once similarity results are materialized. The qualified-column fix is correct regardless and prevents the latent bug from surfacing.